### PR TITLE
Fix: Make emulated VRAM size configurable from userspace

### DIFF
--- a/kexec.c
+++ b/kexec.c
@@ -145,12 +145,12 @@ int sys_kexec(void *td, struct sys_kexec_args *uap)
         goto cleanup;
     }
 
+    set_nix_info(image, bp, initramfs, initramfs_size, cmd_line, uap->vram_gb);
+
     // Initialize bp
     // TODO should probably do this from cpu_quiesce_gate, then bp doesn't
     // need to be allocated here, just placed directly into low mem
     prepare_boot_params(bp, image);
-
-    set_nix_info(image, bp, initramfs, initramfs_size, cmd_line, uap->vram_gb);
 
     // Hook the final ICC shutdown function
     if (!kernel_hook_install(hook_icc_query_nowait, icc_query_nowait)) {


### PR DESCRIPTION
In linux_boot.c `prepare_boot_params()` uses `vram_gb` before you set it in `set_nix_info()`.
Thus you need to call `set_nix_info()` first in order to make `vram_gb` a configurable option.