### PR TITLE
Add 7.55 offsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ CC = $(TOOLCHAIN_PREFIX)gcc
 AR = $(TOOLCHAIN_PREFIX)ar
 OBJCOPY = $(TOOLCHAIN_PREFIX)objcopy
 
-CFLAGS=$(CFLAG) -DPS4_7_00 -DKASLR -DNO_SYMTAB -DDO_NOT_REMAP_RWX
+CFLAGS=$(CFLAG) -DPS4_7_55 -DKASLR -DNO_SYMTAB -DDO_NOT_REMAP_RWX
 CFLAGS += -march=btver2 -masm=intel -std=gnu11 -ffreestanding -fno-common \
 	-fPIE -pie -fno-stack-protector -fomit-frame-pointer -nostdlib -nostdinc \
 	-fno-asynchronous-unwind-tables \
-	-Os -Wall -Werror -Wl,--build-id=none,-T,kexec.ld,--nmagic \
+	-Os -Wall -Werror -Wl,--no-dynamic-linker,--build-id=none,-T,kexec.ld,--nmagic \
 	-mcmodel=small -mno-red-zone
 
 SOURCES := kernel.c kexec.c linux_boot.c linux_thunk.S uart.c firmware.c \

--- a/magic.h
+++ b/magic.h
@@ -237,4 +237,33 @@
 #define kern_off_edid 0x27645e0
 #define kern_off_wlanbt 0xdecb0
 #define kern_off_kern_reboot 0x002CD780 //mira
+
+#elif defined PS4_7_55
+#define kern_off_printf	0x26F740   //mira
+#define kern_off_snprintf 0x26FA40  //mira
+#define kern_off_copyin	0x28F9F0  //mira
+#define kern_off_copyout 0x28F900  //mira
+#define kern_off_copyinstr 0x28FEA0  //mira
+#define kern_off_kmem_alloc_contig 0x49DF40 
+#define kern_off_kmem_free 0x1755B0  //mira
+#define kern_off_pmap_extract 0x1A4DE0
+#define kern_off_pmap_protect 0x1A7F10
+#define kern_off_sched_pin 0x191410
+#define kern_off_sched_unpin 0x191430
+#define kern_off_smp_rendezvous	0x26CEC0
+#define kern_off_smp_no_rendevous_barrier 0x26CC90
+#define kern_off_icc_query_nowait 0x1629D0
+#define kern_off_kernel_map 0x21405B8 //mira
+#define kern_off_sysent	0x1122340 //mira
+#define kern_off_kernel_pmap_store 0x21B0588
+#define kern_off_Starsha_UcodeInfo 0
+#define kern_off_gpu_devid_is_9924 0x4E4560
+#define kern_off_gc_get_fw_info	0x4F8FE0
+#define kern_off_pml4pml4i 0x215EA30 // (lea     rdx, kern_off_pml4pml4i => movsxd  rdi, cs:kern_off_pml4pml4i)c
+#define kern_off_dmpml4i 0x215EA34 
+#define kern_off_dmpdpi	0x215EA38
+#define kern_off_eap_hdd_key 0x26D4C90
+#define kern_off_edid 0x275C0D0
+#define kern_off_wlanbt	0xE3B70
+#define kern_off_kern_reboot 0x02CD780 // mira
 #endif

--- a/magic.h
+++ b/magic.h
@@ -246,7 +246,7 @@
 #define kern_off_copyinstr 0x28FEA0  //mira
 #define kern_off_kmem_alloc_contig 0x49DF40 
 #define kern_off_kmem_free 0x1755B0  //mira
-#define kern_off_pmap_extract 0x1A4DE0
+#define kern_off_pmap_extract 0x1A6D70
 #define kern_off_pmap_protect 0x1A7F10
 #define kern_off_sched_pin 0x191410
 #define kern_off_sched_unpin 0x191430
@@ -255,7 +255,7 @@
 #define kern_off_icc_query_nowait 0x1629D0
 #define kern_off_kernel_map 0x21405B8 //mira
 #define kern_off_sysent	0x1122340 //mira
-#define kern_off_kernel_pmap_store 0x21B0588
+#define kern_off_kernel_pmap_store 0x215EA40
 #define kern_off_Starsha_UcodeInfo 0
 #define kern_off_gpu_devid_is_9924 0x4E4560
 #define kern_off_gc_get_fw_info	0x4F8FE0


### PR DESCRIPTION
This commit adds the offsets for 7.55 hopefully all correct.

Update with the fixed payload: 
[kernel.log](https://github.com/sleirsgoevy/ps4-kexec/files/6168112/kernel.log)

https://user-images.githubusercontent.com/9693338/111719833-fd1f7c80-885c-11eb-87ab-be791abd5d29.mov

Reboots to blue LED with orange rest mode LED blinking

Another update: 
![MVIMG_20210319_101235](https://user-images.githubusercontent.com/9693338/111757635-d2084d80-889b-11eb-979f-d7f9161f6bd5.jpg)

I have a rescue shell :D
